### PR TITLE
Troca diretorio para o do script, permitindo que o script seja rodado de fora

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -17,6 +17,13 @@ Disponibilizar o diretório "deployments" e o arquivo "run.conf" conforme estrut
 
         sh run.sh
         
+Sugestão: manter apenas uma cópia do arquivo run.sh em uma pasta no diretório do usuário, por exemplo:
+	/home/user/docker/run.sh
+E então definir um alias global para este script - abra um terminal na pasta do usuário, digite o comando 
+	vi .bashrc
+E adicione uma nova linha no arquivo
+	alias docker-run="sh /home/alanschaeffer/docker/run.sh"
+A partir do momento que abrir uma nova instância do terminal, poderá navegar para a pasta de ambiente do projeto, que vai conter somente run.conf e a pasta deployments dessa vez, e executar docker-run, que irá executar o script de iniciar o jboss na pasta atual. Por enquanto, temos essa solução para eliminar a necessidade de ficar atualizando os scripts em todos os ambientes configurados quando houverem atualizações.
 
 Banco, portas e jboss (jboss7 ou wildfly) ficam definidos no arquivo de configuração run.conf
 

--- a/dev/run.sh
+++ b/dev/run.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+cd $SCRIPT_DIR
+
 if [ -f run.conf ]
 then
 	. ./run.conf

--- a/dev/run.sh
+++ b/dev/run.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
-cd $SCRIPT_DIR
-
 if [ -f run.conf ]
 then
 	. ./run.conf


### PR DESCRIPTION
Talvez fosse melhor mudarmos um pouco esse lance:
- Configurar o script no ambiente, para podermos rodar ele tipo docker-run de qualquer diretório
- Deixar ele ver os arquivos no diretório corrente, ao invés de trocar pro diretório do script
- Então pra iniciar o docker do zenda, por exemplo, podemos fazer tipo digitar docker-run dentro da pasta do zenda que vai conter somente o conf e o deployments
